### PR TITLE
Kill unknown props React warning 

### DIFF
--- a/src/react-swing.tsx
+++ b/src/react-swing.tsx
@@ -127,7 +127,7 @@ class ReactSwing extends React.Component<IReactSwingProps, IReactSwingState> {
   render() {
     const { children } = this.props;
 
-    const { setStack, ...tagProps } = Object.keys(this.props).reduce((result, key) => {
+    const { setStack, config, ...tagProps } = Object.keys(this.props).reduce((result, key) => {
       if (ReactSwing.EVENTS.indexOf(key as swing.Event) === -1) {
         result[key] = this.props[key];
       }

--- a/src/react-swing.tsx
+++ b/src/react-swing.tsx
@@ -127,7 +127,7 @@ class ReactSwing extends React.Component<IReactSwingProps, IReactSwingState> {
   render() {
     const { children } = this.props;
 
-    const tagProps = Object.keys(this.props).reduce((result, key) => {
+    const { setStack, ...tagProps } = Object.keys(this.props).reduce((result, key) => {
       if (ReactSwing.EVENTS.indexOf(key as swing.Event) === -1) {
         result[key] = this.props[key];
       }


### PR DESCRIPTION
Otherwise you get:

Warning: React does not recognize the `setStack` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `setstack` instead. If you accidentally passed it from a parent component, remove it from the DOM element.